### PR TITLE
Add platform-specific socket setting functions

### DIFF
--- a/util.go
+++ b/util.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pion/sdp/v3"
 	"github.com/pion/turn/v2"
 	"github.com/pion/webrtc/v3"
-	"golang.org/x/sys/unix"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
@@ -362,14 +361,7 @@ func StartTurnServer(ctx context.Context, publicIP string) *turn.Server {
 	// will load-balance received packets per the IP 5-tuple
 	listenerConfig := &net.ListenConfig{
 		Control: func(network, address string, conn syscall.RawConn) error {
-			var operr error
-			if err = conn.Control(func(fd uintptr) {
-				operr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-			}); err != nil {
-				return err
-			}
-
-			return operr
+			return setSocketOptions(network, address, conn)
 		},
 	}
 

--- a/util_unix.go
+++ b/util_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package sfu
+
+func setSocketOptions(network, address string, conn syscall.RawConn) error {
+	var operr error
+	if err := conn.Control(func(fd uintptr) {
+		operr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	}); err != nil {
+		return err
+	}
+
+	return operr
+}

--- a/util_unix.go
+++ b/util_unix.go
@@ -2,10 +2,15 @@
 
 package sfu
 
+import (
+	"golang.org/x/sys/unix"
+	"syscall"
+)
+
 func setSocketOptions(network, address string, conn syscall.RawConn) error {
 	var operr error
 	if err := conn.Control(func(fd uintptr) {
-		operr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		operr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 	}); err != nil {
 		return err
 	}

--- a/util_windows.go
+++ b/util_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package sfu
+
+import "syscall"
+
+func setSocketOptions(network, address string, conn syscall.RawConn) error {
+	var operr error
+	if err := conn.Control(func(fd uintptr) {
+		operr = syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	}); err != nil {
+		return err
+	}
+
+	return operr
+}


### PR DESCRIPTION
The commit introduces two new files called `util_windows.go` and `util_unix.go` which contain specific socket options' settings for Windows and Unix. These functions replace the previous implementation in `util.go`, resulting in cleaner code and segregating functionalities based on the system platform.